### PR TITLE
Update configuration variable name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ services:
 Create a `config.js` file:
 
 ``` js
-window.DROPMIND_CONFIG = {
+window.DM_CONFIG = {
   API_BASE_URL: "http://localhost:8000",
   API_TOKEN: "your-secure-token"
 };


### PR DESCRIPTION
The readme has us define `DROPMIND_CONFIG`, but the frontend expects `DM_CONFIG`.

This PR makes the readme's CONFIG object name match the name found in [index.html:1577](https://github.com/oldany/dropmind/blob/main/frontend/index.html#L1577).